### PR TITLE
cmake: don't install headers if PokeLib is used as a submodule for another project, standard builds are unaffected

### DIFF
--- a/include/pokelib/CMakeLists.txt
+++ b/include/pokelib/CMakeLists.txt
@@ -1,5 +1,7 @@
 FILE(GLOB pokelib_headers RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
 
-FOREACH(header ${pokelib_headers})
-    INSTALL(FILES ${header} DESTINATION ${INCLUDE_DIR}/pokelib COMPONENT Headers)
-ENDFOREACH(header)
+IF(NOT USED_AS_SUBMODULE)
+    FOREACH(header ${pokelib_headers})
+        INSTALL(FILES ${header} DESTINATION ${INCLUDE_DIR}/pokelib COMPONENT Headers)
+    ENDFOREACH(header)
+ENDIF(NOT USED_AS_SUBMODULE)


### PR DESCRIPTION
As the commit says, you won't notice anything. PKMNsim uses my mirror of PokeLib as a Git submodule and links against the library. When using my trainer class, all the user specifies is a filename and the game to expect it to be. If it's Gen 3, it uses Pokehack; if it's Gen 4, it uses PokeLib. The user doesn't see the underlying implementation, just my interface. Thus, beyond build time, PKMNsim doesn't need the PokeLib headers.

When installing PokeLib standalone, the headers are still installed.
